### PR TITLE
Fix comparison under clang/libc++

### DIFF
--- a/snss-parse-lib.hpp
+++ b/snss-parse-lib.hpp
@@ -393,11 +393,11 @@ int get_file_size(std::ifstream& f) {
 bool open_and_check_file(std::ifstream& f, int *filesize) {
     *filesize = get_file_size(f);
 
-    char magic[4];
+    char magic[4] = "";
     read_char(f, magic, 4);
     read_arbitrary<uint32_t>(f, 4); // version
 
-    if (0 != std::strcmp("SNSS", magic)) {
+    if (0 != std::strncmp("SNSS", magic, 4)) {
         std::cerr << "Error: Not a valid SNSS file." << std::endl;
         return false;
     }


### PR DESCRIPTION
`magic` was possibly not terminated with NUL (`\0`) and so the comparison was failing

![image](https://user-images.githubusercontent.com/3579195/100733827-0defd380-33cf-11eb-8730-8162986a3669.png)
